### PR TITLE
fix: table pagination bug when front-end paging

### DIFF
--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -159,6 +159,10 @@ const ErdaTable = <T extends Obj>({
     data = data.sort(sortCompareRef.current);
   }
 
+  if (isFrontendPaging) {
+    data = data.slice((current - 1) * pageSize, current * pageSize);
+  }
+
   return (
     <div className={cn(`${prefixCls}`, { [`${prefixCls}-hide-header`]: extraConfig?.hideHeader })}>
       {!extraConfig?.hideHeader && (


### PR DESCRIPTION
In the case of front-end paging,  fixed the bug of tables showed all data.